### PR TITLE
Add shared Android build workflow

### DIFF
--- a/.github/workflows/android_build.yml
+++ b/.github/workflows/android_build.yml
@@ -1,0 +1,53 @@
+name: Build
+
+on:
+  workflow_call:
+    inputs:
+      deploy-snapshot-github:
+        description: 'Deploy Snapshot build to GitHub'
+        default: false
+        type: boolean
+        required: false
+
+      deploy-snapshot-maven:
+        description: 'Deploy Snapshot build to Maven'
+        default: false
+        type: boolean
+        required: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Validate Gradle Wrapper
+        uses: gradle/actions/wrapper-validation@v4
+
+      - uses: gradle/actions/setup-gradle@v3
+
+      - name: Build and run tests
+        run: ./gradlew spotlessCheck build
+
+      - name: Deploy SNAPSHOT to GitHub Packages
+        if: ${{ inputs.deploy-snapshot-github == true }}
+        run: ./gradlew publish --stacktrace
+        env:
+          ORG_GRADLE_PROJECT_githubPackagesUsername: ${{ github.actor }}
+          ORG_GRADLE_PROJECT_githubPackagesPassword: ${{ github.token }}
+
+      - name: Deploy SNAPSHOT to Maven Central
+        if: ${{ inputs.deploy-snapshot-maven == true }}
+        run: ./gradlew publish --stacktrace
+        env:
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONOTYPE_MAVEN_ACCOUNT_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONOTYPE_MAVEN_ACCOUNT_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.MAVEN_GPG_SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.MAVEN_GPG_SIGNING_PASSPHRASE }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# Apple
+.DS_Store
+**/.DS_Store
+


### PR DESCRIPTION
This PR adds a shared GitHub Action that can be used to build (and deploy snapshots) across the various Android repositories. An input is required to optionally deploy the snapshot, either to GitHub or Maven (or both).

I tested this shared action here: https://github.com/openpass-sso/openpass-android-sdk/pull/234