### PR TITLE
Add shared Android release workflow

### DIFF
--- a/.github/workflows/android_release.yml
+++ b/.github/workflows/android_release.yml
@@ -1,0 +1,163 @@
+name: Android Release
+run-name: ${{ format('Release version {0}', inputs.version)}} by @${{ github.actor }}
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: 'Release version (without v)'
+        required: true
+        type: string
+
+      snapshot:
+        description: 'Next SNAPSHOT version (without v). Defaults to current value'
+        required: false
+        type: string
+
+      deploy-github:
+        description: 'Deploy build to GitHub'
+        default: false
+        type: boolean
+        required: false
+
+      deploy-maven:
+        description: 'Deploy build to Maven'
+        default: false
+        type: boolean
+        required: false
+
+      decrypt-secrets:
+        description: 'Whether there are secrets that need to be decrypted before release'
+        default: false
+        type: boolean
+        required: false
+
+      release_assets:
+        description:
+        default: 'Newline-delimited list of path globs for asset files to upload as part of the GitHub release'
+        type: string
+        required: false
+
+jobs:
+  publish:
+    name: Android Release
+    runs-on: ubuntu-latest
+    env:
+      ORG_GRADLE_PROJECT_OPEN_PASS_RELEASE_KEYSTORE_PWD: ${{ secrets.ORG_GRADLE_PROJECT_OPEN_PASS_RELEASE_KEYSTORE_PWD }}
+      ORG_GRADLE_PROJECT_OPEN_PASS_RELEASE_KEY_PWD: ${{ secrets.ORG_GRADLE_PROJECT_OPEN_PASS_RELEASE_KEY_PWD }}
+
+    permissions:
+      id-token: write
+      contents: write
+      packages: write
+
+    steps:
+      - name: Generate build number
+        shell: bash
+        run: echo "ORG_GRADLE_PROJECT_OPEN_PASS_VERSION_CODE=$(( $GITHUB_RUN_NUMBER + 10000 ))" >> $GITHUB_ENV
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Update Git user
+        run: |
+          git config --local user.name "openpass-sso"
+          git config --local user.email openpass-sso@users.noreply.github.com
+
+      - name: Validate Gradle Wrapper
+        uses: gradle/actions/wrapper-validation@v4
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Decrypt secrets
+        if: ${{ inputs.decrypt-secrets == true }}
+        run: ./scripts/decrypt-secrets.sh
+        env:
+          ENCRYPT_KEY: ${{ secrets.ENCRYPT_KEY }}
+
+      - name: Get Snapshot versions
+        id: snapshot-versions
+        run: ./scripts/get_snapshot_versions.sh ${{ inputs.snapshot }}
+
+      - name: Update Gradle properties
+        shell: bash
+        run: |
+          sed -i.bak "s/${{ steps.snapshot-versions.outputs.cur_snapshot_version }}/${{ inputs.version }}/g" gradle.properties
+
+      - name: Commit Gradle properties
+        run: |
+          git add gradle.properties
+          git commit -m "Prepare for release: ${{ inputs.version }}"
+
+      - name: Deploy v${{ inputs.version }} (GitHub)
+        if: ${{ inputs.deploy-github == true }}
+        run: ./gradlew publish
+        env:
+          ORG_GRADLE_PROJECT_githubPackagesUsername: ${{ github.actor }}
+          ORG_GRADLE_PROJECT_githubPackagesPassword: ${{ github.token }}
+
+      - name: Deploy v${{ inputs.version }} (Maven)
+        if: ${{ inputs.deploy-maven == true }}
+        run: ./gradlew publish
+        env:
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONOTYPE_MAVEN_ACCOUNT_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONOTYPE_MAVEN_ACCOUNT_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.MAVEN_GPG_SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.MAVEN_GPG_SIGNING_PASSPHRASE }}
+
+      - name : Build Locally
+        if: ${{ inputs.deploy-github == false && inputs.deploy-maven == false }}
+        run: ./gradlew build
+
+      - name: Tag release
+        run: |
+          git tag "v${{ inputs.version }}"
+
+      - name: Update Gradle properties (Snapshot)
+        shell: bash
+        run: |
+          sed -i.bak "s/${{ inputs.version }}/${{ steps.snapshot-versions.outputs.new_snapshot_version }}/g" gradle.properties
+
+      - name: Commit Gradle properties (Snapshot)
+        run: |
+          git add gradle.properties
+          git commit -m "Prepare next development version: ${{ steps.snapshot-versions.outputs.new_snapshot_version }}"
+
+      - name: Cleanup
+        shell: bash
+        run: |
+          rm gradle.properties.bak
+
+      - name: Authenticate using Release Version GitHub App
+        id: auth
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ vars.RELEASE_VERSION_BOT_APP_ID }}
+          private_key: ${{ secrets.RELEASE_VERSION_BOT_PRIVATE_KEY }}
+
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          branch: ${{ github.ref }}
+          github_token: ${{ steps.auth.outputs.token }}
+
+      - name: Push changes to tag
+        uses: ad-m/github-push-action@master
+        with:
+          branch: ${{ github.ref }}
+          tags: true
+          push_only_tags: true
+
+      - name: GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: ${{ inputs.release_assets }}
+          generate_release_notes: true
+          tag_name: v${{ inputs.version }}


### PR DESCRIPTION
This PR adds a shared GitHub Action that can be used to release across the various Android repositories. An input is required to specify if the release should be either GitHub or Maven (or both).