### PR TITLE
Fix checkout for release workflow

### DIFF
--- a/.github/workflows/android_release.yml
+++ b/.github/workflows/android_release.yml
@@ -58,6 +58,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal access token.
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4


### PR DESCRIPTION
As identified by @christriddle-thetradedesk, we need to ensure that the token is not persisted during the checkout. This will allow us to push the commit as the release GitHub App.
