### PR TITLE
Fix missing permission to write to GitHub packages

### DIFF
--- a/.github/workflows/android_build.yml
+++ b/.github/workflows/android_build.yml
@@ -17,7 +17,11 @@ on:
 
 jobs:
   build:
+    name: Android Build
     runs-on: ubuntu-latest
+
+    permissions:
+      packages: write
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
In order to deploy to GitHub packages, we need to also request the permission. This was missing which resulted in 403s when attempting to deploy.