### PR TITLE
Add missing contents/read permission

### DIFF
--- a/.github/workflows/android_build.yml
+++ b/.github/workflows/android_build.yml
@@ -21,6 +21,7 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
+      contents: read
       packages: write
 
     steps:


### PR DESCRIPTION
Context: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token

> If you specify the access for any of these permissions, all of those that are not specified are set to none.

After adding the requirement to write packages, it's downgraded our access to read the contents of the repo.