### PR TITLE
Use Central Portal credentials for maven publishing

### DIFF
--- a/.github/workflows/android_build.yml
+++ b/.github/workflows/android_build.yml
@@ -50,7 +50,7 @@ jobs:
         if: ${{ inputs.deploy-snapshot-maven == true }}
         run: ./gradlew publish --stacktrace
         env:
-          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONOTYPE_MAVEN_ACCOUNT_USERNAME }}
-          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONOTYPE_MAVEN_ACCOUNT_PASSWORD }}
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.CENTRAL_SONATYPE_MAVEN_ACCOUNT_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.CENTRAL_SONATYPE_MAVEN_ACCOUNT_PASSWORD }}
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.MAVEN_GPG_SIGNING_KEY }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.MAVEN_GPG_SIGNING_PASSPHRASE }}

--- a/.github/workflows/android_release.yml
+++ b/.github/workflows/android_release.yml
@@ -108,8 +108,8 @@ jobs:
         if: ${{ inputs.deploy-maven == true }}
         run: ./gradlew publish
         env:
-          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONOTYPE_MAVEN_ACCOUNT_USERNAME }}
-          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONOTYPE_MAVEN_ACCOUNT_PASSWORD }}
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.CENTRAL_SONATYPE_MAVEN_ACCOUNT_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.CENTRAL_SONATYPE_MAVEN_ACCOUNT_PASSWORD }}
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.MAVEN_GPG_SIGNING_KEY }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.MAVEN_GPG_SIGNING_PASSPHRASE }}
 


### PR DESCRIPTION
<!--
## Note to author:
* Please fill in this template fully for every PR.
* For FE features, it is a requirement to include screenshots and/or videos of the feature working. Videos are preferred. However, all changes will benefit from screenshots of testing evidence.
* Ensure the size and complexity of your PR is as small as possible. This will help the reviewer give a good review.
* Choose your reviewer wisely - they should be SMEs in the area of change. Multiple reviewers for complex changes are encouraged.
-->
## Note to reviewer:
* The reviewer is responsible for the functionality of this PR working correctly just as much as the author. It is encouraged for the reviewer to check out the change and test according to the test plan.

## What does this PR solve?

Maven OSSRH is reaching [end of life](https://central.sonatype.org/news/20250326_ossrh_sunset/). Use new credentials to publish to Central Portal.

## Test plan

We will test a snapshot release from `openpass-android-sdk` in https://github.com/openpass-sso/openpass-android-sdk/pull/303